### PR TITLE
Move VNet Reconciliation to the Cluster Actuator

### DIFF
--- a/cloud/azure/actuators/cluster/clusteractuator.go
+++ b/cloud/azure/actuators/cluster/clusteractuator.go
@@ -82,7 +82,7 @@ func (azure *AzureClusterClient) Reconcile(cluster *clusterv1.Cluster) error {
 		return fmt.Errorf("error waiting for network security group creation or update: %v", err)
 	}
 
-	// Reconcile virutal network
+	// Reconcile virtual network
 	vnetFuture, err := azure.network().CreateOrUpdateVnet(clusterConfig.ResourceGroup, "", clusterConfig.Location)
 	if err != nil {
 		return fmt.Errorf("error creating or updating virtual network: %v", err)

--- a/cloud/azure/actuators/cluster/clusteractuator.go
+++ b/cloud/azure/actuators/cluster/clusteractuator.go
@@ -66,11 +66,13 @@ func (azure *AzureClusterClient) Reconcile(cluster *clusterv1.Cluster) error {
 		return fmt.Errorf("error loading cluster provider config: %v", err)
 	}
 
+	// Reconcile resource group
 	_, err = azure.resourcemanagement().CreateOrUpdateGroup(clusterConfig.ResourceGroup, clusterConfig.Location)
 	if err != nil {
 		return fmt.Errorf("failed to create or update resource group: %v", err)
 	}
 
+	// Reconcile network security group
 	networkSGFuture, err := azure.network().CreateOrUpdateNetworkSecurityGroup(clusterConfig.ResourceGroup, "ClusterAPINSG", clusterConfig.Location)
 	if err != nil {
 		return fmt.Errorf("error creating or updating network security group: %v", err)
@@ -78,6 +80,16 @@ func (azure *AzureClusterClient) Reconcile(cluster *clusterv1.Cluster) error {
 	err = azure.network().WaitForNetworkSGsCreateOrUpdateFuture(*networkSGFuture)
 	if err != nil {
 		return fmt.Errorf("error waiting for network security group creation or update: %v", err)
+	}
+
+	// Reconcile virutal network
+	vnetFuture, err := azure.network().CreateOrUpdateVnet(clusterConfig.ResourceGroup, "", clusterConfig.Location)
+	if err != nil {
+		return fmt.Errorf("error creating or updating virtual network: %v", err)
+	}
+	err = azure.network().WaitForVnetCreateOrUpdateFuture(*vnetFuture)
+	if err != nil {
+		return fmt.Errorf("error waiting for virtual network creation or update: %v", err)
 	}
 	return nil
 }

--- a/cloud/azure/actuators/machine/deployment-template.json
+++ b/cloud/azure/actuators/machine/deployment-template.json
@@ -183,8 +183,7 @@
         }
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddresses_ClusterAPI_ip_name'))]",
-        "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworks_ClusterAPIVM_vnet_name'), parameters('subnets_default_name'))]"
+        "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddresses_ClusterAPI_ip_name'))]"
       ]
     },
     {
@@ -202,47 +201,6 @@
         "idleTimeoutInMinutes": 4
       },
       "dependsOn": []
-    },
-    {
-      "type": "Microsoft.Network/virtualNetworks",
-      "name": "[parameters('virtualNetworks_ClusterAPIVM_vnet_name')]",
-      "apiVersion": "2017-06-01",
-      "location": "[parameters('location')]",
-      "scale": null,
-      "properties": {
-        "provisioningState": "Succeeded",
-        "resourceGuid": "27c506b7-4879-45c2-9eae-480c5289de48",
-        "addressSpace": {
-          "addressPrefixes": [
-            "10.0.0.0/24"
-          ]
-        },
-        "subnets": [
-          {
-            "name": "[parameters('subnets_default_name')]",
-            "etag": "W/\"2d36bb91-8d73-4836-b61b-658cb73debbc\"",
-            "properties": {
-              "provisioningState": "Succeeded",
-              "addressPrefix": "10.0.0.0/24"
-            }
-          }
-        ],
-        "virtualNetworkPeerings": []
-      },
-      "dependsOn": []
-    },
-    {
-      "type": "Microsoft.Network/virtualNetworks/subnets",
-      "name": "[concat(parameters('virtualNetworks_ClusterAPIVM_vnet_name'), '/', parameters('subnets_default_name'))]",
-      "apiVersion": "2017-06-01",
-      "scale": null,
-      "properties": {
-        "provisioningState": "Succeeded",
-        "addressPrefix": "10.0.0.0/24"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworks_ClusterAPIVM_vnet_name'))]"
-      ]
     },
     {
       "apiVersion": "2015-06-15",

--- a/cloud/azure/services/interfaces.go
+++ b/cloud/azure/services/interfaces.go
@@ -50,6 +50,10 @@ type AzureNetworkClient interface {
 	// Public Ip Address Operations
 	DeletePublicIpAddress(resourceGroup string, IPName string) (network.PublicIPAddressesDeleteFuture, error)
 	WaitForPublicIpAddressDeleteFuture(future network.PublicIPAddressesDeleteFuture) error
+
+	// Virtual Networks Operations
+	CreateOrUpdateVnet(resourceGroupName string, virtualNetworkName string, location string) (*network.VirtualNetworksCreateOrUpdateFuture, error)
+	WaitForVnetCreateOrUpdateFuture(future network.VirtualNetworksCreateOrUpdateFuture) error
 }
 
 type AzureResourceManagementClient interface {

--- a/cloud/azure/services/mock_interfaces.go
+++ b/cloud/azure/services/mock_interfaces.go
@@ -37,6 +37,9 @@ type MockAzureNetworkClient struct {
 
 	MockDeletePublicIpAddress              func(resourceGroup string, IPName string) (network.PublicIPAddressesDeleteFuture, error)
 	MockWaitForPublicIpAddressDeleteFuture func(future network.PublicIPAddressesDeleteFuture) error
+
+	MockCreateOrUpdateVnet              func(resourceGroupName string, virtualNetworkName string, location string) (*network.VirtualNetworksCreateOrUpdateFuture, error)
+	MockWaitForVnetCreateOrUpdateFuture func(future network.VirtualNetworksCreateOrUpdateFuture) error
 }
 
 type MockAzureResourceManagementClient struct {
@@ -108,6 +111,7 @@ func (m *MockAzureNetworkClient) WaitForPublicIpAddressDeleteFuture(future netwo
 	}
 	return m.MockWaitForPublicIpAddressDeleteFuture(future)
 }
+
 func (m *MockAzureNetworkClient) CreateOrUpdateNetworkSecurityGroup(resourceGroupName string, networkSecurityGroupName string, location string) (*network.SecurityGroupsCreateOrUpdateFuture, error) {
 	if m.MockCreateOrUpdateNetworkSecurityGroup == nil {
 		return nil, nil
@@ -127,6 +131,20 @@ func (m *MockAzureNetworkClient) WaitForNetworkSGsCreateOrUpdateFuture(future ne
 		return nil
 	}
 	return m.MockWaitForNetworkSGsCreateOrUpdateFuture(future)
+}
+
+func (m *MockAzureNetworkClient) CreateOrUpdateVnet(resourceGroupName string, virtualNetworkName string, location string) (*network.VirtualNetworksCreateOrUpdateFuture, error) {
+	if m.MockCreateOrUpdateVnet == nil {
+		return nil, nil
+	}
+	return m.MockCreateOrUpdateVnet(resourceGroupName, virtualNetworkName, location)
+}
+
+func (m *MockAzureNetworkClient) WaitForVnetCreateOrUpdateFuture(future network.VirtualNetworksCreateOrUpdateFuture) error {
+	if m.MockWaitForVnetCreateOrUpdateFuture == nil {
+		return nil
+	}
+	return m.MockWaitForVnetCreateOrUpdateFuture(future)
 }
 
 func (m *MockAzureResourceManagementClient) CreateOrUpdateGroup(resourceGroupName string, location string) (resources.Group, error) {

--- a/cloud/azure/services/network/service.go
+++ b/cloud/azure/services/network/service.go
@@ -23,6 +23,7 @@ type Service struct {
 	InterfacesClient        network.InterfacesClient
 	PublicIPAddressesClient network.PublicIPAddressesClient
 	SecurityGroupsClient    network.SecurityGroupsClient
+	VirtualNetworksClient   network.VirtualNetworksClient
 	ctx                     context.Context
 }
 
@@ -31,6 +32,7 @@ func NewService(subscriptionId string) *Service {
 		InterfacesClient:        network.NewInterfacesClient(subscriptionId),
 		PublicIPAddressesClient: network.NewPublicIPAddressesClient(subscriptionId),
 		SecurityGroupsClient:    network.NewSecurityGroupsClient(subscriptionId),
+		VirtualNetworksClient:   network.NewVirtualNetworksClient(subscriptionId),
 		ctx:                     context.Background(),
 	}
 }
@@ -39,4 +41,5 @@ func (s *Service) SetAuthorizer(authorizer autorest.Authorizer) {
 	s.InterfacesClient.BaseClient.Client.Authorizer = authorizer
 	s.PublicIPAddressesClient.BaseClient.Client.Authorizer = authorizer
 	s.SecurityGroupsClient.BaseClient.Client.Authorizer = authorizer
+	s.VirtualNetworksClient.BaseClient.Client.Authorizer = authorizer
 }

--- a/cloud/azure/services/network/virtualnetworks.go
+++ b/cloud/azure/services/network/virtualnetworks.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package network
+
+import (
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-01-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+)
+
+const (
+	VnetDefaultName          = "ClusterAPIVnet"
+	SubnetDefaultName        = "ClusterAPISubnet"
+	defaultPrivateSubnetCIDR = "10.0.0.0/24"
+)
+
+func (s *Service) CreateOrUpdateVnet(resourceGroupName string, virtualNetworkName string, location string) (*network.VirtualNetworksCreateOrUpdateFuture, error) {
+	if virtualNetworkName == "" {
+		virtualNetworkName = VnetDefaultName
+	}
+
+	subnets := []network.Subnet{
+		network.Subnet{
+			Name: to.StringPtr(SubnetDefaultName),
+			SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
+				AddressPrefix: to.StringPtr(defaultPrivateSubnetCIDR),
+			},
+		},
+	}
+	virtualNetworkProperties := network.VirtualNetworkPropertiesFormat{
+		AddressSpace: &network.AddressSpace{&[]string{defaultPrivateSubnetCIDR}},
+		Subnets:      &subnets,
+	}
+	virtualNetwork := network.VirtualNetwork{
+		Location:                       to.StringPtr(location),
+		VirtualNetworkPropertiesFormat: &virtualNetworkProperties,
+	}
+	sgFuture, err := s.VirtualNetworksClient.CreateOrUpdate(s.ctx, resourceGroupName, virtualNetworkName, virtualNetwork)
+	if err != nil {
+		return nil, err
+	}
+	return &sgFuture, nil
+}
+
+func (s *Service) WaitForVnetCreateOrUpdateFuture(future network.VirtualNetworksCreateOrUpdateFuture) error {
+	return future.Future.WaitForCompletionRef(s.ctx, s.VirtualNetworksClient.Client)
+}


### PR DESCRIPTION
This moves handling of VNets from the machine actuator to the cluster actuator. 

Machines in the same cluster are all connected to the same virtual network and each has its own NIC.

Closes #9 