### PR TITLE
Pin kube version in startup scripts

### DIFF
--- a/cloud/azure/actuators/machine/machineactuator.go
+++ b/cloud/azure/actuators/machine/machineactuator.go
@@ -470,12 +470,11 @@ systemctl daemon-reload
 systemctl restart kubelet.service
 
 PORT=6443
-PRIVATEIP=$(curl -H Metadata:true "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/privateIpAddress?api-version=2017-04-01&format=text")
-PUBLICIP=$(curl -H Metadata:true "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/publicIpAddress?api-version=2017-04-02&format=text")
+PUBLICIP=$(curl -H Metadata:true "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/publicIpAddress?api-version=2017-08-01&format=text")
 
 # Set up kubeadm config file to pass parameters to kubeadm init.
 cat > kubeadm_config.yaml <<EOF
-apiVersion: kubeadm.k8s.io/v1alpha1
+apiVersion: kubeadm.k8s.io/v1alpha2
 kind: MasterConfiguration
 api:
   advertiseAddress: ${PUBLICIP}
@@ -513,7 +512,7 @@ cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 apt-get update
-apt-get install -y kubelet kubeadm kubectl
+apt-get install -y kubelet=1.11.3-00 kubeadm=1.11.3-00 kubectl=1.11.3-00
 
 CLUSTER_DNS_SERVER=$(prips "10.96.0.0/12" | head -n 11 | tail -n 1)
 CLUSTER_DNS_DOMAIN="cluster.local"

--- a/cloud/azure/actuators/machine/machineactuator.go
+++ b/cloud/azure/actuators/machine/machineactuator.go
@@ -456,7 +456,7 @@ cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 apt-get update
-apt-get install -y kubelet kubeadm kubectl
+apt-get install -y kubelet=1.11.3-00 kubeadm=1.11.3-00 kubectl=1.11.3-00 kubernetes-cni=0.6.0-00
 
 CLUSTER_DNS_SERVER=$(prips "10.96.0.0/12" | head -n 11 | tail -n 1)
 CLUSTER_DNS_DOMAIN="cluster.local"

--- a/cloud/azure/actuators/machine/machineactuator_test.go
+++ b/cloud/azure/actuators/machine/machineactuator_test.go
@@ -165,7 +165,7 @@ cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 apt-get update
-apt-get install -y kubelet kubeadm kubectl
+apt-get install -y kubelet=1.11.3-00 kubeadm=1.11.3-00 kubectl=1.11.3-00 kubernetes-cni=0.6.0-00
 
 CLUSTER_DNS_SERVER=$(prips "10.96.0.0/12" | head -n 11 | tail -n 1)
 CLUSTER_DNS_DOMAIN="cluster.local"
@@ -179,12 +179,11 @@ systemctl daemon-reload
 systemctl restart kubelet.service
 
 PORT=6443
-PRIVATEIP=$(curl -H Metadata:true "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/privateIpAddress?api-version=2017-04-01&format=text")
-PUBLICIP=$(curl -H Metadata:true "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/publicIpAddress?api-version=2017-04-02&format=text")
+PUBLICIP=$(curl -H Metadata:true "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/publicIpAddress?api-version=2017-08-01&format=text")
 
 # Set up kubeadm config file to pass parameters to kubeadm init.
 cat > kubeadm_config.yaml <<EOF
-apiVersion: kubeadm.k8s.io/v1alpha1
+apiVersion: kubeadm.k8s.io/v1alpha2
 kind: MasterConfiguration
 api:
   advertiseAddress: ${PUBLICIP}

--- a/configtemplates/provider-components.yaml.template
+++ b/configtemplates/provider-components.yaml.template
@@ -253,7 +253,7 @@ data:
 
           # Set up kubeadm config file to pass parameters to kubeadm init.
           cat > /etc/kubernetes/kubeadm_config.yaml <<EOF
-          apiVersion: kubeadm.k8s.io/v1alpha1
+          apiVersion: kubeadm.k8s.io/v1alpha2
           kind: MasterConfiguration
           api:
             advertiseAddress: ${PUBLICIP}


### PR DESCRIPTION
Uses a fixed kubernetes version number for startup scripts on master and agent nodes to avoid unpredictable behavior with deprecations.

Ideally, we should find a better way to bootstrap other than. This PR is just a workaround for now to bootstrap Kubernetes properly on the VMs. I've opened #24 to track this.